### PR TITLE
EncodingSelector 9r55hs

### DIFF
--- a/fileioapp/src/main/java/ch/heig/dai/lab/fileio/_9r55hs/EncodingSelector.java
+++ b/fileioapp/src/main/java/ch/heig/dai/lab/fileio/_9r55hs/EncodingSelector.java
@@ -2,6 +2,9 @@ package ch.heig.dai.lab.fileio._9r55hs;
 
 import java.io.File;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Dictionary;
+import java.util.Hashtable;
 
 public class EncodingSelector {
 
@@ -17,7 +20,15 @@ public class EncodingSelector {
      * @return the encoding of the file, or null if the extension is not recognized
      */
     public Charset getEncoding(File file) {
-        // TODO: implement the method body here
-        return null;
+        Dictionary<String, Charset> extensions = new Hashtable<>();
+        extensions.put("utf8",      StandardCharsets.UTF_8);
+        extensions.put("txt",       StandardCharsets.US_ASCII);
+        extensions.put("utf16be",   StandardCharsets.UTF_16BE);
+        extensions.put("utf16le",   StandardCharsets.UTF_16LE);
+
+        String[] splitFilename = file.toString().split("\\.");
+        String fileExt = splitFilename[splitFilename.length - 1];
+
+        return extensions.get(fileExt);
     }
 }

--- a/fileioapp/src/test/java/ch/heig/dai/lab/fileio/_9r55hs/EncodingSelectorTest.java
+++ b/fileioapp/src/test/java/ch/heig/dai/lab/fileio/_9r55hs/EncodingSelectorTest.java
@@ -12,7 +12,6 @@ public class EncodingSelectorTest {
     private final EncodingSelector selector = new EncodingSelector();
 
     @Test
-    @Disabled
     public void encodingTest() {
         assertEquals (StandardCharsets.UTF_8, selector.getEncoding(new File("file1.utf8")));
         assertEquals (StandardCharsets.US_ASCII, selector.getEncoding(new File("file1.txt")));
@@ -21,14 +20,12 @@ public class EncodingSelectorTest {
     }
 
     @Test
-    @Disabled
     public void nullTest() {
         assertEquals (null, selector.getEncoding(new File("file1.utf")));
         assertEquals (null, selector.getEncoding(new File("file1")));
     }
 
     @Test
-    @Disabled
     public void dotsTests() {
         assertEquals (StandardCharsets.UTF_8, selector.getEncoding(new File("file1.txt.utf8")));
         assertEquals (StandardCharsets.US_ASCII, selector.getEncoding(new File("file1.utf8.txt")));


### PR DESCRIPTION
EncodingSelector 9r55hs.
Closes issue #164 

> **Note**: The folders are named '_9r55hs' to avoid problems in Java